### PR TITLE
fix: log received RF codes in chunks to avoid truncation

### DIFF
--- a/ESPHome config.yaml
+++ b/ESPHome config.yaml
@@ -64,16 +64,20 @@ remote_receiver:
   on_raw:
     then:
       - lambda: |-
-          // Log as single copyable line for YAML
-          std::string code_str = "";
-          for (int i = 0; i < x.size(); i++) {
-            if (i > 0) code_str += ", ";
-            code_str += std::to_string(x[i]);
-          }
+          // Log in chunks so each line fits the ESPHome log buffer (~256 chars).
+          // Reassemble: part0 + ", " + part1 + ", " + ... -> code: [...]
           ESP_LOGI("raw_code", "Pulses: %d", x.size());
-          ESP_LOGI("raw_code", "Copy this line:");
-          ESP_LOGI("raw_code", "[%s]", code_str.c_str());
-          
+          ESP_LOGI("raw_code", "Copy each part line in order, then concatenate with ', ':");
+          const int chunk = 40;
+          for (int i = 0; i < (int)x.size(); i += chunk) {
+            std::string s;
+            for (int j = i; j < (int)x.size() && j < i + chunk; j++) {
+              if (j > i) s += ", ";
+              s += std::to_string(x[j]);
+            }
+            ESP_LOGI("raw_code", "part %d: %s", i / chunk, s.c_str());
+          }
+
           // Learning mode logic
           if (id(learning_mode)) {
             id(learned_code).clear();

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Learn and replay 433 MHz RF signals from remotes, blinds, outlets, and more — 
 
 - **Learn RF signals** — Capture signals from any 433 MHz remote
 - **Replay signals** — Retransmit learned signals on demand (single or x3)
-- **Single-line log output** — Captured codes logged as copyable arrays
+- **Chunked log output** — Captured codes logged in copyable chunks that fit the log buffer
 - **Dual pin wiring** — Simultaneous TX/RX without mode switching
 - **Home Assistant integration** — Full control via buttons, switches, and sensors
 - **Web interface** — Built-in web server on port 80 for standalone use
@@ -105,15 +105,25 @@ Pin numbering may vary between modules. Always verify with your module's datashe
 
 ### Copying Raw Codes from Logs
 
-Every received signal is logged as a single copyable line in the ESPHome console:
+Every received signal is logged in **chunks** so each line fits within the ESPHome log buffer (~256 chars). Long codes are split across multiple `part` lines that you reassemble into a single array:
 
 ```
-[I][raw_code:xxx]: Pulses: 122
-[I][raw_code:xxx]: Copy this line:
-[I][raw_code:xxx]: [592, -635, 266, -295, 617, -615, 268, -309, ...]
+[I][raw_code:xxx]: Pulses: 182
+[I][raw_code:xxx]: Copy each part line in order, then concatenate with ', ':
+[I][raw_code:xxx]: part 0: 592, -635, 266, -295, 617, -615, 268, -309, ...   (40 values)
+[I][raw_code:xxx]: part 1: 590, -640, 264, -301, 615, -612, 270, -305, ...   (40 values)
+[I][raw_code:xxx]: part 2: 588, -638, 269, -298, 614, -618, 266, -302, ...  (remaining values)
+```
+
+To rebuild the full code, concatenate the parts in order, separating each with `, `:
+
+```
+code: [part0 values, part1 values, part2 values]
 ```
 
 You can paste this array directly into the YAML config as a permanent button.
+
+> **Why chunks?** ESPHome truncates log lines that exceed its buffer. Without chunking, longer codes are cut off mid-sequence and cannot be reconstructed.
 
 ---
 


### PR DESCRIPTION
## Problem

ESPHome truncates log lines that exceed its buffer (~256 chars). When a captured RF code is too long, the logged output is cut off mid-sequence and the user cannot read or reconstruct it.

## Fix

Log raw codes in **chunks** of 40 values across multiple `part` lines, with instructions to reassemble by concatenating the parts with `, `:

```
[I][raw_code:xxx]: Pulses: 182
[I][raw_code:xxx]: Copy each part line in order, then concatenate with ', ':
[I][raw_code:xxx]: part 0: 592, -635, 266, -295, ...   (40 values)
[I][raw_code:xxx]: part 1: 590, -640, 264, -301, ...   (40 values)
[I][raw_code:xxx]: part 2: 588, -638, 269, -298, ...   (remaining values)
```

## Changes

- **ESPHome config.yaml** — Replaced the single-line log output in the `on_raw` lambda with chunked logging. Learning-mode logic is preserved unchanged.
- **README.md** — Updated the "Copying Raw Codes from Logs" section to document the new chunked format and reassembly steps, and updated the Features bullet from "Single-line log output" to "Chunked log output".

This is a non-breaking change — existing short codes still log fine, and learning/replay behavior is unchanged.